### PR TITLE
Install Django templates as package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ install_requires =
     wheel>=0.33
 
 [options.package_data]
-* = *.rst
+* =
+ *.rst
+ templates/*
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
Because:
- We do want templates in production also :-)