### PR TITLE
Determine package version using git tags

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = aas
-version = attr: aas.__version__
 description = XXX: FILL THIS OUT, one short line/elevator pitch
 long_description = file: README.md
 long_description_content_type='text/markdown'
@@ -20,6 +19,7 @@ package_dir =
     = src
 setup_requires =
     setuptools>=41.0
+    setuptools_scm==3.5.0
     wheel>=0.33
 install_requires =
     setuptools>=41.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
 
 
-setup()
+setup(
+    use_scm_version = True,
+)


### PR DESCRIPTION
Because:
- The aas module did not have a __version__ attribute, causing setup.py
  to fail.
- Using setuptools_scm to determine package version from git tags is a
  lot more maintanable than actually hardcoding a version variable into
  a file in the repo.